### PR TITLE
Permit root ssh login

### DIFF
--- a/virtualbox.json
+++ b/virtualbox.json
@@ -20,6 +20,12 @@
         "{{user `password`}}",
         "<enter>",
         "<wait>",
+        "sed -i 's/PasswordAuthentication no/PasswordAuthentication yes/' /etc/ssh/sshd_config",
+        "<enter>",
+        "<wait>",
+        "echo 'PermitRootLogin yes' >> /etc/ssh/sshd_config",
+        "<enter>",
+        "<wait>",
         "/etc/init.d/sshd start",
         "<enter>",
         "<wait>"


### PR DESCRIPTION
Alter /etc/ssh/sshd_config to permit root ssh login.

First, toggle PasswordAuthentication to yes, second, permit root logins.