### PR TITLE
Update stage3 and fix grub command

### DIFF
--- a/scripts/grub.sh
+++ b/scripts/grub.sh
@@ -3,6 +3,6 @@
 chroot /mnt/gentoo /bin/bash <<'EOF'
 emerge ">=sys-boot/grub-2.0"
 echo "set timeout=0" >> /etc/grub.d/40_custom
-grub2-install /dev/sda
-grub2-mkconfig -o /boot/grub/grub.cfg
+grub-install /dev/sda
+grub-mkconfig -o /boot/grub/grub.cfg
 EOF

--- a/scripts/network.sh
+++ b/scripts/network.sh
@@ -3,7 +3,7 @@
 chroot /mnt/gentoo /bin/bash <<'EOF'
 sed -i 's/^#\s*GRUB_CMDLINE_LINUX=.*/GRUB_CMDLINE_LINUX="net.ifnames=0"/' \
   /etc/default/grub
-grub2-mkconfig -o /boot/grub/grub.cfg
+grub-mkconfig -o /boot/grub/grub.cfg
 ln -s /etc/init.d/net.lo /etc/init.d/net.eth0
 echo 'config_eth0=( "dhcp" )' >> /etc/conf.d/net
 rc-update add net.eth0 default

--- a/virtualbox.json
+++ b/virtualbox.json
@@ -35,7 +35,7 @@
       "guest_additions_mode": "disable",
       "guest_os_type": "Gentoo_64",
       "headless": false,
-      "iso_checksum": "1fe353fec7142a551348ba3aa1b42dcf73df8ad815340f7da30239357f8d6b2fa4a5e2db8075efde9b3c28fcf16b62d5f8045cfb9c57fa0bda55821fe5390d44",
+      "iso_checksum": "77056442a5af47d4d361ff0259daafaf898d3fb9a4d19802333190e614d69da5866ab06993590b129c60a35783e82f6d19b913790dcc42871e29c6af4869b507",
       "iso_checksum_type": "sha512",
       "iso_url": "http://distfiles.gentoo.org/releases/amd64/autobuilds/{{user `stage3`}}/install-amd64-minimal-{{user `stage3`}}.iso",
       "shutdown_command": "shutdown -hP now",
@@ -73,7 +73,7 @@
   ],
   "variables": {
     "password": "packer",
-    "stage3": "20150702",
+    "stage3": "20160929",
     "username": "root"
   }
 }


### PR DESCRIPTION
Updated to latest iso and stage3. Fixed grub2 command calls (grub2-\* is now called grub-*). Tested successfully on macOS Sierra and current VirtualBox/Vagrant/Packer versions.
