### PR TITLE
Update virtualbox-guest-additions to 5.0.20

### DIFF
--- a/scripts/virtualbox.sh
+++ b/scripts/virtualbox.sh
@@ -5,9 +5,9 @@ emerge "=virtual/linux-sources-1" --autounmask-write
 etc-update --automode -5
 emerge "=virtual/linux-sources-1"
 
-emerge ">=app-emulation/virtualbox-guest-additions-4.3" --autounmask-write
+emerge ">=app-emulation/virtualbox-guest-additions-5.0.20" --autounmask-write
 etc-update --automode -5
-emerge ">=app-emulation/virtualbox-guest-additions-4.3"
+emerge ">=app-emulation/virtualbox-guest-additions-5.0.20"
 
 rc-update add virtualbox-guest-additions default
 EOF


### PR DESCRIPTION
Updated virtualbox-guest-additions to 5.0.20. Tested successfully on macOS Sierra and current VirtualBox/Vagrant/Packer versions.
